### PR TITLE
Function arguments can be scalars or sequences; and add more tests

### DIFF
--- a/echopype/tests/utils/test_utils_misc.py
+++ b/echopype/tests/utils/test_utils_misc.py
@@ -1,23 +1,31 @@
+import pytest
+
 import numpy as np
 from echopype.utils.misc import depth_from_pressure
 
 
 def test_depth_from_pressure():
-    # Test with a single pressure value
-    pressure = 10000.0
-    latitude = 30.0
-    depth = depth_from_pressure(pressure, latitude)
-    assert np.isclose(depth, 9712.653)
+    # A single pressure value and defaults for the other arguments
+    pressure = 100.0
+    depth = depth_from_pressure(pressure)
+    assert np.isclose(depth, 99.2954)
 
-    # Test with an array of pressure values
-    pressure = np.array([10000.0, 10001.0, 10002.0])
-    latitude = 30.0
+    # Array of pressure and list of latitude values
+    pressure = np.array([100.0, 101.0, 101.0])
+    latitude = [0.0, 30.0, 50.0]
     depth = depth_from_pressure(pressure, latitude)
-    assert np.allclose(depth, [9712.653, 9713.604, 9714.556])
+    assert np.allclose(depth, [99.4265, 100.2881, 100.1096])
 
-    # Test with a different latitude value
-    pressure = 10000.0
-    latitude = 34.0
-    depth = depth_from_pressure(pressure, latitude)
-    assert np.isclose(depth, 9709.439)
+    # Scalars specified for all 3 arguments
+    pressure = 1000.0
+    latitude = 0.0
+    atm_pres_surf = 10.1325  # standard atm pressure at sea level
+    depth = depth_from_pressure(pressure, latitude, atm_pres_surf)
+    assert np.isclose(depth, 982.0882)
 
+    # ValueError triggered by argument arrays having different lengths
+    pressure = np.array([100.0, 101.0, 101.0])
+    latitude = [0.0, 30.0]
+    with pytest.raises(ValueError) as excinfo:
+        depth = depth_from_pressure(pressure, latitude)
+    assert str(excinfo.value) == "Sequence shape or size does not match pressure"

--- a/echopype/utils/misc.py
+++ b/echopype/utils/misc.py
@@ -50,7 +50,7 @@ def depth_from_pressure(pressure, latitude=30, atm_pres_surf=0):
 
     # Calculate depth
     pressure = pressure - atm_pres_surf
-    depth_w_g = c4 * pressure**4 + c3 * pressure**3 + c2 * pressure**2 + c1 * pressure
+    depth_w_g = c1 * pressure + c2 * pressure**2 + c3 * pressure**3 + c4 * pressure**4
     x = np.sin(np.deg2rad(latitude))
     gravity = g * (1.0 + k1 * x**2 + k2 * x**4) + k3 * pressure
     depth = depth_w_g / gravity


### PR DESCRIPTION
@praneethratna I made some enhancements to your PR (https://github.com/OSOceanAcoustics/echopype/pull/1207):
- Generalizing function arguments so that any of them can be a scalar or a sequence. Added consistency checks
- Added type hints to the function
- Added more tests

If this looks good to you, please merge into your PR, then we can finalize the PR.

Thanks!